### PR TITLE
Remove console log printed when uploading a file to Glance

### DIFF
--- a/lib/glance.js
+++ b/lib/glance.js
@@ -105,7 +105,7 @@ Glance.prototype.listImages = function(cb)
   this.request.get(request_options, function(error, response, body){
     var images_array = [];
     var n = 0;
-    
+
     if(osutils.isError(error, response) || !body.images)
     {
       cb(osutils.getError('glance.list', error, response, body));
@@ -227,8 +227,6 @@ Glance.prototype.uploadImage = function(id, stream, cb)
     });
 
     res.on('end', function(){
-      //TODO: UNKNOWN what reponse is at this time.
-      console.log('Upload done:', response)
       cb(null, response);
     });
   });


### PR DESCRIPTION
Response from the Glance API when uploading a file is empty (evaluated as an empty string in `response`) when the upload succeed.
Anyway, there should be not log printed on the standard output.