### PR TITLE
Add listRegions to Keystone

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ OSWrap.getSimpleProject('username', 'password', 'project_id', 'keystone_url', fu
 * **Flavors**
   * listFlavors(callback)
   * getFlavor(flavor_id, callback)
+* **Project Networks**
+  * listProjectNetworks(callback)
 * **Floating Ips**
   * listFloatingIps(callback)
   * listFloatingIps(options, callback)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ OSWrap.getSimpleProject('username', 'password', 'project_id', 'keystone_url', fu
 * listRoleAssignments(project_token_value, project_id, callback)
 * addRoleAssignment(project_token_value, project_id, entry_id, entry_type, role_id, callback)
 * removeRoleAssignment(project_token_value, project_id, entry_id, entry_type, role_id, callback)
+* listRegions(generic_token_value, callback)
 
 ### Nova (aka Compute)
 * new Nova(v2_public_url, project_token_value)

--- a/README.md
+++ b/README.md
@@ -298,6 +298,15 @@ OSWrap.getSimpleProject('username', 'password', 'project_id', 'keystone_url', fu
   * updateLBPoolMember(pool_id, member_id, options_obj, cb(error, result_obj))
   * removeLBPoolMember(pool_id, member_id, cb(error))
 
+### Heat (aka Orchestration)
+* new Heat(v1_public_url, project_token_value)
+* setTimeout(timeout_milliseconds)
+* **Stacks**
+  * listStacks(options_obj, cb(error, result_obj))
+  * createStack(stack_name, options_obj, cb(error, result_obj))
+  * updateStack(stack_name, stack_id, options_obj, cb(error, result_obj))
+  * deleteStack(stack_name, stack_id, cb(error, result_obj))
+
 
 ## Running Tests
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var Glance = require('./lib/glance');
 var Neutron = require('./lib/neutron');
 var Octavia = require('./lib/octavia');
 var Nova = require('./lib/nova');
+var Heat = require('./lib/heat');
 
 //A convenience method for quick/dirty work for those that already have a project_id
 //calls back with (error, project) where project already has all the individual objects setup
@@ -15,6 +16,7 @@ function getSimpleProject(username, password, project_id, keystone_url, cb)
   var neutron_url = '';
   var nova_url = '';
   var octavia_url = '';
+  var heat_url = '';
   var catalog_array = [];
   var n = 0;
   var j = 0;
@@ -73,6 +75,10 @@ function getSimpleProject(username, password, project_id, keystone_url, cb)
             {
               octavia_url = endpoints_array[j].url;
             }
+            else if (endpoint_type == 'orchestration')
+            {
+              heat_url = endpoints_array[j].url;
+            }
             break;
           }
         }
@@ -84,6 +90,7 @@ function getSimpleProject(username, password, project_id, keystone_url, cb)
       return_object.neutron = new Neutron(neutron_url, project_token.token);
       return_object.nova = new Nova(nova_url, project_token.token);
       return_object.octavia = new Octavia(octavia_url, project_token.token);
+      return_object.heat = new Heat(heat_url, project_token.token);
       cb(null, return_object);
     });
   });
@@ -97,5 +104,6 @@ module.exports = {
   Neutron: Neutron,
   Octavia: Octavia,
   Nova: Nova,
+  Heat: Heat,
   getSimpleProject: getSimpleProject
 }

--- a/lib/heat.js
+++ b/lib/heat.js
@@ -228,10 +228,6 @@ Heat.prototype.updateStack = function(name, id, options, cb)
       throw new Error('heat.updateStack: requires `id` (string) parameter');
   }
   options = args[2] || {};
-  if ((typeof options.template != 'object') &&
-      (typeof options.template_url != 'string')) {
-      throw new Error('heat.updateStack: requires either `options.template` (object) or `options.template_url` (string) parameter');
-  }
   cb = args[3];
 
   var self = this;

--- a/lib/heat.js
+++ b/lib/heat.js
@@ -1,0 +1,293 @@
+var OSUtils = require('./os-utils');
+var Request = require('./os-request');
+
+
+//constructor - should be the only export
+function Heat(endpoint_url, auth_token)
+{
+  //set this way purely to facilitate unit test dependency injetion
+  this.request = Request;
+
+  //this is an optional lib that we override to normalfy the openstack responses - leave as is for no munging
+  this.mangler = require('./mangler');
+  this.mangleObject = this.mangler.mangleObject;
+
+  //endpoint_url should come from the keystone projectInfo call - also yank all the trailing slashes in case folks get clever
+  this.url = endpoint_url.replace(/\/$/, "");
+
+  //auth_token should be the scoped token from the projectInfo call
+  this.token = auth_token;
+
+  //default the timeout to false - this forces the static value to be used
+  this.timeout = 9000;
+
+  //default request id to blank - should represent the incomming request id
+  this.request_id = '';
+
+  //default to a blank user_name
+  this.user_name = '';
+
+  //logger should default to null - might consider checking for a logMetric function in that obj too?
+  this.logger = null;
+}
+
+
+//setters for individual obj/call usage
+//just set these prior to doing things and your good to go until you want to change it
+Heat.prototype.setTimeout = function(new_timeout)
+{
+  this.timeout = new_timeout;
+};
+
+Heat.prototype.setRequestID = function(request_id)
+{
+  this.request_id = request_id;
+};
+
+Heat.prototype.setUserName = function(user_name)
+{
+  this.user_name = user_name;
+};
+
+Heat.prototype.setLogger = function(logger)
+{
+  this.logger = logger;
+};
+
+//this should only be used for dependency injection
+Heat.prototype.setRequest = function(request_lib)
+{
+  this.request = request_lib;
+}
+
+//lets us mangle/sanitize/make sane the various responses from openstack
+//any replacement must simply support a static mangleObject that supports the following types [ie mangleObject(type, object)]
+//Image
+Heat.prototype.setMangler = function(mangle_lib)
+{
+  this.mangler = mangle_lib;
+  this.mangleObject = this.mangler.mangleObject;
+}
+
+
+
+//returns an formatted options object - just makes the code below a little less repetitious
+//path should begin with a "/"
+//json_value should be almost certainly be true if you don't have an actual object you want to send over
+Heat.prototype.getRequestOptions = function(path, json_value, extra_headers)
+{
+  var return_object = {
+    uri: this.url + path,
+    headers:{'X-Auth-Token': this.token},
+    json: json_value,
+    timeout: this.timeout,
+    metricRequestID: this.request_id,
+    metricUserName: this.user_name,
+    metricLogger: this.logger
+  };
+
+  //add the extra header info if it exists
+  if(typeof extra_headers != 'undefined')
+  {
+    for(var key in extra_headers)
+    {
+      if(extra_headers.hasOwnProperty(key))
+      {
+        return_object.headers[key] = extra_headers[key];
+      }
+    }
+  }
+
+  return return_object;
+};
+
+
+
+//gets a list of all stacks for the given project/tenant
+//calls back with cb(error, stack_array)
+// the options object can be used to specify filters, e.g.:
+//{
+//    id: string,
+//    status: string,
+//    name: string,
+//    action: string,
+//    tenant: string,
+//    username: string,
+//    owner_id: string
+//}
+Heat.prototype.listStacks = function(options, cb)
+{
+  var self = this;
+  var args = OSUtils.getArgsWithCallback(this.listStacks.length, arguments);
+  options = args[0] || {};
+  cb = args[1];
+
+  var request_options = this.getRequestOptions('/stacks', true);
+  request_options.qs = options;
+  request_options.metricPath = 'remote-calls.heat.stacks.list';
+  request_options.validateStatus = true;
+  request_options.requireBodyObject = 'stacks';
+
+  this.request.get(request_options, function(error, response, body){
+    var stacks_array = [];
+    var n = 0;
+
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+    //else
+
+    for (n = 0; n < body.stacks.length; n++)
+    {
+      stacks_array[n] = self.mangleObject('Stack', body.stacks[n]);
+    }
+
+    cb(null, stacks_array);
+  });
+}
+
+
+
+//creates a stack with the given name
+//calls back with cb(error, stack_object)
+// options:
+// {
+//   disable_rollback: boolean,
+//   environment: object,
+//   files: object,
+//   parameters: object,
+//   tags: string,
+//   template: object,
+//   template_url: string,
+//   timeout_mins: number
+//}
+//note: either template or template_url must be defined
+Heat.prototype.createStack = function(name, options, cb)
+{
+  var self = this;
+  var args = OSUtils.getArgsWithCallback(this.createStack.length, arguments);
+  name = args[0];
+  if (typeof name != 'string') {
+      throw new Error('heat.createStack: requires `name` (string) parameter');
+  }
+  options = args[1] || {};
+  if ((typeof options.template != 'object') &&
+      (typeof options.template_url != 'string')) {
+      throw new Error('heat.createStack: requires either `options.template` (object) or `options.template_url` (string) parameter');
+  }
+  cb = args[2];
+
+  options.stack_name = name;
+  var request_options = this.getRequestOptions('/stacks', options);
+  request_options.metricPath = 'remote-calls.heat.stacks.create';
+  request_options.validateStatus = true;
+  request_options.requireBodyObject = 'stack';
+
+  this.request.post(request_options, function(error, response, body){
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+    //else
+
+    cb(null, self.mangleObject('Stack', body.stack));
+  });
+}
+
+
+
+//updates the stack with the given name and id, using HTTP PATCH
+//calls back with cb(error, stack_object)
+// options:
+// {
+//   clear_parameters: array,
+//   disable_rollback: boolean,
+//   environment: object,
+//   environment_files: object,
+//   files: object,
+//   parameters: object,
+//   tags: string,
+//   template: object,
+//   template_url: string,
+//   timeout_mins: number,
+//   converge: boolean
+//}
+//note: either template or template_url must be defined
+Heat.prototype.updateStack = function(name, id, options, cb)
+{
+  var args = OSUtils.getArgsWithCallback(this.updateStack.length, arguments);
+  name = args[0];
+  if (typeof name != 'string') {
+      throw new Error('heat.updateStack: requires `name` (string) parameter');
+  }
+  id = args[1];
+  if (typeof id != 'string') {
+      throw new Error('heat.updateStack: requires `id` (string) parameter');
+  }
+  options = args[2] || {};
+  if ((typeof options.template != 'object') &&
+      (typeof options.template_url != 'string')) {
+      throw new Error('heat.updateStack: requires either `options.template` (object) or `options.template_url` (string) parameter');
+  }
+  cb = args[3];
+
+  var self = this;
+  var request_options = this.getRequestOptions('/stacks/' + escape(name) + '/' + escape(id), options);
+  request_options.metricPath = 'remote-calls.heat.stacks.update';
+  request_options.validateStatus = true;
+
+  this.request.patch(request_options, function(error, response, body){
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+    //else
+
+    cb();
+  });
+}
+
+
+
+//deletes the stack with the given name and id
+Heat.prototype.deleteStack = function(name, id, cb)
+{
+  if (typeof name != 'string') {
+      throw new Error('heat.deleteStack: requires `name` (string) parameter');
+  }
+  if (typeof id != 'string') {
+      throw new Error('heat.deleteStack: requires `id`  (string) parameter');
+  }
+
+  var request_options = this.getRequestOptions('/stacks/' + escape(name) + '/' + escape(id), true);
+  request_options.metricPath = 'remote-calls.heat.stack.delete';
+  request_options.validateStatus = true;
+
+  //are we not giving this a cb for some reason sometimes???
+  function noop()
+  {
+    //this does absolutely nothing - and thats just the way we like it!
+  }
+  if(!cb)
+  {
+    cb = noop;
+  }
+
+  this.request.del(request_options, function(error, response, body){
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+    //else
+
+    cb();
+  });
+}
+
+
+module.exports = Heat;

--- a/lib/heat.js
+++ b/lib/heat.js
@@ -148,6 +148,39 @@ Heat.prototype.listStacks = function(options, cb)
   });
 }
 
+//show output of a stack for the given key name
+//calls back with cb(error, output_object)
+Heat.prototype.showStackOutput = function(name, id, outputKey, cb)
+{
+  if (typeof name != 'string') {
+      throw new Error('heat.showStackOutput: requires `name` (string) parameter');
+  }
+  if (typeof id != 'string') {
+      throw new Error('heat.showStackOutput: requires `id`  (string) parameter');
+  }
+  if (typeof outputKey != 'string') {
+      throw new Error('heat.showStackOutput: requires `outputKey`  (string) parameter');
+  }
+
+  var request_options = this.getRequestOptions('/stacks/' + escape(name) + '/' + escape(id) + '/outputs/' + escape(outputKey), true);
+
+  request_options.metricPath = 'remote-calls.heat.stack.showStackOutput';
+  request_options.validateStatus = true;
+
+  this.request.get(request_options, function(error, response, body){
+
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+    //else
+
+    cb(null, body.output);
+  });
+
+}
+
 
 
 //creates a stack with the given name

--- a/lib/keystone.js
+++ b/lib/keystone.js
@@ -468,6 +468,39 @@ Keystone.prototype.removeRoleAssignment = function(project_token, project_id, en
 
 
 
+//gets a list of all regions in the system
+//calls back with cb(error, region_array)
+Keystone.prototype.listRegions = function(access_token, cb)
+{
+  var self = this;
+  var request_options = this.getRequestOptions(access_token, '/regions', true);
+  request_options.metricPath = 'remote-calls.keystone.regions.list';
+  request_options.validateStatus = true;
+  request_options.requireBodyObject = 'regions';
+
+  this.request.get(request_options, function(error, response, body){
+    var regions_array =[];
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+
+    for(var n = 0; n < body.regions.length; n++)
+    {
+      regions_array[n] = self.mangleObject('Region', body.regions[n]);
+    }
+
+    //tack these on for easy consupmtion and in case we ever need pagination
+    regions_array.self = body.links.self;
+    regions_array.previous = body.links.previous;
+    regions_array.next = body.links.next;
+
+    cb(null, regions_array);
+  });
+};
+
+
 
 //THE FOLLOWING ARE ONLY USEFUL WITHIN GODADDY (and are prioprietary functions until/if the project meta data work is adopted)
 //THUS THEY AREN"T DOCUMENTED

--- a/lib/nova.js
+++ b/lib/nova.js
@@ -640,6 +640,39 @@ Nova.prototype.getFlavor = function(id, cb)
 
 
 // ----------------
+// ProjectNetwork
+// ----------------
+Nova.prototype.listProjectNetworks = function(cb)
+{
+  var self = this;
+  var projectNetworks_array = [];
+  var request_options = this.getRequestOptions('/os-tenant-networks', true);
+  request_options.metricPath = 'remote-calls.nova.os-tenant-networks.list';
+  request_options.validateStatus = true;
+  request_options.requireBodyObject = 'networks';
+
+  this.request.get(request_options, function(error, response, body){
+    if(error)
+    {
+      cb(error);
+      return;
+    }
+    //else we need to arrayify mangle the response(s)
+
+    for(var n = 0; n < body.networks.length; n++)
+    {
+      projectNetworks_array[n] = self.mangleObject('ProjectNetwork', body.networks[n]);
+    }
+
+    //theres no self, prev, or next pagiation stuff so just return the array
+    cb(null, projectNetworks_array);
+  });
+};
+
+
+
+
+// ----------------
 // Floating IP
 // ----------------
 Nova.prototype.listFloatingIps = function(cb)

--- a/test/heat-test.js
+++ b/test/heat-test.js
@@ -1,0 +1,203 @@
+var util = require('util');
+var Heat = require('../lib/heat.js');
+var heat = new Heat('http://mock_heat_url', 'mock_token');
+
+
+
+//returns a mock request object for dependency injection with get/post/patch/del methods calling back with the given 3 values
+function getMockRequest(return_error, return_status_code, return_response)
+{
+  function mockVerb(options_array, callback)
+  {
+    callback(return_error, {statusCode: return_status_code}, return_response);
+  }
+
+  var return_object = {
+    get:mockVerb,
+    post: mockVerb,
+    patch: mockVerb,
+    put: mockVerb,
+    del: mockVerb
+  };
+
+  return return_object;
+}
+
+
+
+exports.getRequestOptions = {
+  setUp: function(cb){
+    cb();
+  },
+
+  confirmResult: function(test){
+    var result = heat.getRequestOptions('/mock_path', {meh: 'meh'});
+    var expected_result = {
+      uri: 'http://mock_heat_url/mock_path',
+      headers:{'X-Auth-Token': 'mock_token'},
+      json: {meh: 'meh'},
+      timeout: 9000,
+      metricRequestID: '',
+      metricUserName: '',
+      metricLogger: null
+    };
+
+    test.deepEqual(result, expected_result, 'result should be ' + JSON.stringify(expected_result));
+    test.done();
+  }
+};
+
+
+
+exports.listStacks = {
+  setUp: function(cb){
+    this.valid_response_body = {stacks: [{id: 1}, {id: 2}]};
+    this.valid_result = [{id: 1}, {id: 2}];
+
+    cb();
+  },
+
+  confirmValidResultOnSuccess: function(test)
+  {
+    //stub out a request obj with a completely valid response
+    var self = this;
+    var mock_request = getMockRequest(null, 200, this.valid_response_body);
+    heat.setRequest(mock_request);
+
+    heat.listStacks(function(error, result){
+      test.ifError(error, 'There should be no error');
+      test.deepEqual(result, self.valid_result, 'result should be ' + JSON.stringify(self.valid_result));
+      test.done();
+    });
+  },
+
+
+  confirmErrorOnError: function(test)
+  {
+    //stub out some junk with an error
+    var mock_request = getMockRequest(new Error('meh'), 500, {});
+    heat.setRequest(mock_request);
+
+    heat.listStacks(function(error, result){
+      test.ok(error, 'We should receive an error object or string');
+      test.done();
+    });
+  }
+};
+
+
+
+exports.createStack = {
+  setUp: function(cb){
+    this.valid_response_body = {stack: {id: 'mock_id'}};
+    this.valid_result = {id: 'mock_id'};
+
+    cb();
+  },
+
+  confirmValidResultOnSuccess: function(test)
+  {
+    //stub out a request obj with a completely valid response
+    var self = this;
+    var mock_request = getMockRequest(null, 200, this.valid_response_body);
+    heat.setRequest(mock_request);
+
+    const options = {
+        template_url: "http://mock_template_url"
+    };
+    heat.createStack('mock_stack_name', options, function(error, result){
+      test.ifError(error, 'There should be no error');
+      test.deepEqual(result, self.valid_result, 'result should be ' + JSON.stringify(self.valid_result));
+      test.done();
+    });
+  },
+
+  confirmErrorOnError: function(test)
+  {
+    //stub out some junk with an error
+    var mock_request = getMockRequest(new Error('meh'), 500, {});
+    heat.setRequest(mock_request);
+
+    const options = {
+        template_url: "http://mock_template_url"
+    };
+    heat.createStack('mock_stack_name', options, function(error, result){
+      test.ok(error, 'We should receive an error object');
+      test.done();
+    });
+  }
+};
+
+
+
+exports.updateStack = {
+  setUp: function(cb){
+    cb();
+  },
+
+  confirmValidResultOnSuccess: function(test)
+  {
+    //stub out a request obj with a completely valid response
+    var self = this;
+    var mock_request = getMockRequest(null, 200, {});
+    heat.setRequest(mock_request);
+
+    const options = {
+        template_url: "http://mock_template_url"
+    };
+    heat.updateStack('mock_stack_name', 'mock_stack_id', options, function(error, result){
+      test.ifError(error, 'There should be no error');
+      test.deepEqual(result, self.valid_result, 'result should be ' + JSON.stringify(self.valid_result));
+      test.done();
+    });
+  },
+
+  confirmErrorOnError: function(test)
+  {
+    //stub out some junk with an error
+    var mock_request = getMockRequest(new Error('meh'), 500, {});
+    heat.setRequest(mock_request);
+
+    const options = {
+        template_url: "http://mock_template_url"
+    };
+    heat.updateStack('mock_stack_name', 'mock_stack_id', options, function(error, result){
+      test.ok(error, 'We should receive an error object');
+      test.done();
+    });
+  }
+};
+
+
+
+exports.deleteStack = {
+  setUp: function(cb){
+    cb();
+  },
+
+  confirmValidResultOnSuccess: function(test)
+  {
+    //stub out a request obj with a completely valid response
+    var self = this;
+    var mock_request = getMockRequest(null, 200, {});
+    heat.setRequest(mock_request);
+
+    heat.deleteStack('mock_stack_name', 'mock_stack_id', function(error, result){
+      test.ifError(error, 'There should be no error');
+      test.deepEqual(result, self.valid_result, 'result should be ' + JSON.stringify(self.valid_result));
+      test.done();
+    });
+  },
+
+  confirmErrorOnError: function(test)
+  {
+    //stub out some junk with an error
+    var mock_request = getMockRequest(new Error('meh'), 500, {});
+    heat.setRequest(mock_request);
+
+    heat.deleteStack('mock_stack_name', 'mock_stack_id', function(error, result){
+      test.ok(error, 'We should receive an error object');
+      test.done();
+    });
+  }
+};

--- a/test/keystone-test.js
+++ b/test/keystone-test.js
@@ -404,6 +404,66 @@ exports.removeRoleAssignment = {
 };
 
 
+exports.listRegions = {
+  setUp: function(cb){
+    //we'll need these a few times so...
+    this.valid_response_body = {links: {self: 'selfurl', previous: null, next: null},
+        regions: [
+            {
+                "description": "",
+                "id": "RegionOne",
+                "links": {
+                    "self": "selfurl"
+                },
+                "parent_region_id": null
+            }
+        ]};
+    this.valid_result = [
+        {
+            "description": "",
+            "id": "RegionOne",
+            "links": {
+                "self": "selfurl"
+            },
+            "parent_region_id": null
+        }
+    ];
+    this.valid_result.self = 'selfurl';
+    this.valid_result.previous = null;
+    this.valid_result.next = null;
+
+    cb();
+  },
+
+
+  confirmRegionsOnSuccess: function(test)
+  {
+    //stub out request with a completely valid response
+    var self = this;
+    var mock_request = getMockRequest(null, 200, {}, this.valid_response_body);
+    keystone.setRequest(mock_request);
+
+    keystone.listRegions('accesstoken', function(error, result){
+      test.ifError(error, 'There should be no error')
+      test.deepEqual(result, self.valid_result, 'result should be ' + JSON.stringify(self.valid_result));
+      test.done();
+    });
+  },
+
+  confirmErrorOnError: function(test)
+  {
+    //stub out request for a 500 with a valid body (worst case scenario)
+    var mock_request = getMockRequest(new Error('meh'), 500, {}, this.valid_response_body);
+    keystone.setRequest(mock_request);
+
+    keystone.listRegions('accesstoken', function(error, result){
+      test.ok(error, "We should receive an error object");
+      test.done();
+    });
+  }
+};
+
+
 exports.listMetaEnvironments = {
   setUp: function(cb){
     this.valid_result = [{id: 'DEV', name: 'Development'}];

--- a/test/nova-test.js
+++ b/test/nova-test.js
@@ -603,6 +603,66 @@ exports.getFlavor = {
 
 
 
+exports.listProjectNetworks = {
+  setUp: function(cb){
+    this.valid_response_body = {
+        networks: [
+            {
+                "cidr": "10.0.0.0/29",
+                "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+                "label": "test_0"
+            },
+            {
+                "cidr": "10.0.0.8/29",
+                "id": "616fb98f-46ca-475e-917e-2563e5a8cd20",
+                "label": "test_1"
+            }
+        ]
+    };
+    this.valid_result = [
+        {
+            "cidr": "10.0.0.0/29",
+            "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+            "label": "test_0"
+        },
+        {
+            "cidr": "10.0.0.8/29",
+            "id": "616fb98f-46ca-475e-917e-2563e5a8cd20",
+            "label": "test_1"
+        }
+    ];
+
+    cb();
+  },
+
+  confirmArrayValuesOnSuccess: function(test)
+  {
+    var self = this;
+    var mock_request = getMockRequest(null, 200, this.valid_response_body);
+    nova.setRequest(mock_request);
+
+    nova.listProjectNetworks(function(error, result){
+      test.ifError(error, 'There should be no error');
+      test.deepEqual(result, self.valid_result, 'value should match object: ' + JSON.stringify(self.valid_result));
+      test.done();
+    });
+  },
+
+  confirmErrorOnError: function(test)
+  {
+    //stub out some junk with an error
+    var mock_request = getMockRequest(new Error('meh'), 500, {});
+    nova.setRequest(mock_request);
+
+    nova.listProjectNetworks(function(error, result){
+      test.ok(error, 'We should receive an error object');
+      test.done();
+    });
+  }
+};
+
+
+
 exports.floatinglistFloatingIpsip_list = {
   confirmArrayOnSuccess: function(test)
   {


### PR DESCRIPTION
It is sometimes necessary to know the list of regions, irrespective of
the regional endpoints listed in the service catalog. This change adds
support for listing regions in the Keystone client, using the Keystone
API https://developer.openstack.org/api-ref/identity/v3/#list-regions

The method was created by copy-pasting the `getProjects` method,
but changing one of the parameter names to indicate that an unscoped
token can be used to authorize the Keystone call.