### PR TITLE
Add domain name for keystone server

### DIFF
--- a/lib/keystone.js
+++ b/lib/keystone.js
@@ -98,14 +98,29 @@ Keystone.prototype.getRequestOptions = function(auth_token, path, json_value)
 //authorizes the users against the specified keystone
 //calls back with (error, token) where token is an object containing all the token info
 //NOTE: the actual token value normally comes back in the header - i'm modifying this to token.token for easier consumption
-Keystone.prototype.getToken = function(username, password, cb)
+Keystone.prototype.getToken = function()
 {
   var self = this;
+  var username = arguments[0];
+  var password = arguments[1];
+  var cb;
+  var domain;
+
+  // Parameters are (username, password, domain, cb)
+  if(arguments.length === 4) {
+    domain = arguments[2];
+    cb = arguments[3];
+  } else {
+  // Parameters are (username, password, cb)
+    domain = 'Default';
+    cb = arguments[2];
+  }
+
   var auth_data = {
     auth:{
       identity:{
         methods: ['password'],
-        'password': {user: {domain: {name: 'Default'}, name: username, 'password': password}}
+        'password': {user: {domain: {name: domain}, name: username, 'password': password}}
       }
     }
   }


### PR DESCRIPTION
# PR Type

At the moment you can not change the domain name of the keystone server (it is hard coded to 'Default')
I've added an option to change the domain of your openstack when calling `getToken`.

I tried to make the code backwards compatible. But the structure of `getToken` had to suffer, because I've used ES5-only features (not ES6) and you can not add optional parameters nicely with ES5. 

# Changes

You can now call the keystone server like this

```JavaScript

new OSWrap.Keystone('http://keystone.uri').getToken('user', 'pass', 'mydomain', function(err, token){})
# or like before..
new OSWrap.Keystone('http://keystone.uri').getToken('user', 'pass', function(err, token){})

```

# Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```