### PR TITLE
Allow mutli-server creation

### DIFF
--- a/lib/nova.js
+++ b/lib/nova.js
@@ -167,7 +167,8 @@ Nova.prototype.createServer = function(data, cb)
   var request_options = this.getRequestOptions('/servers', data);
   request_options.metricPath = 'remote-calls.nova.servers.create';
   request_options.validateStatus = true;
-  request_options.requireBodyObject = 'server';
+  //Commenting out so that we can handle returns of 'servers' for multiple creates
+  //request_options.requireBodyObject = 'server';
 
   this.request.post(request_options, function(error, response, body){
     if(error)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.9",
+  "version": "2.1.10",
   "name": "openstack-wrapper",
   "description": "A simple js wrapper for the Openstack APIs",
   "contributors": [


### PR DESCRIPTION
 - Eliminates the specific check on the server creation result that causes the nova.createServer method from erroring when multi-server options are specified.