### PR TITLE
createServerImage now supports nova 2.45+

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ npm test
 ```
 
 ## Change Log
+### 2.2.0
+
+* Updated Nova.createServerImage to handle Nova 2.45+ format (new output format breaks backwards compat on this method so incrimented minor ver)
+
 ### 2.1.13
 
 * Added Heat object and methods

--- a/lib/nova.js
+++ b/lib/nova.js
@@ -549,7 +549,8 @@ Nova.prototype.createServerImage = function(id, data, cb)
   request_options = this.getRequestOptions('/servers/' + escape(id) + '/action', data);
   request_options.metricPath = 'remote-calls.nova.servers.images.create';
   request_options.validateStatus = true;
-  request_options.requireBodyObject = 'output';
+  //commenting out to support later versions of nova that dont return 
+  //request_options.requireBodyObject = 'output';
   
   this.request.post(request_options, function(error, response, body){
     var url = '';
@@ -560,14 +561,23 @@ Nova.prototype.createServerImage = function(id, data, cb)
       cb(error);
       return;
     }
-    //else
+    //else if nova 2.45+ the image id is in the body, else its in the header (in theory)
 
-    //its useful to also send back the id of the image that was just created - we can get that from the response location apparently?
-    url = response.headers.location;
-    image_id = url.match(/.*\/images\/(.*)/)[1];
-    body.output.ImageId = image_id;
-
-    cb(null, self.mangleObject('ServerImage', body.output));
+    if(body && body.image_id)
+    {
+      //nova 2.45+
+      image_id = body.image_id;
+    }
+    else
+    {
+      //old skool
+      url = response.headers.location;
+      image_id = url.match(/.*\/images\/(.*)/)[1];
+    }
+    
+    //removing ServerImage mangling as we are updating this method with a diffrent format in 2.2+
+    //going to try and output as close to what recent nova does regardless of version of nova used
+    cb(null, {'image_id': image_id});
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.13",
+  "version": "2.2.0",
   "name": "openstack-wrapper",
   "description": "A simple js wrapper for the Openstack APIs",
   "contributors": [

--- a/test/nova-test.js
+++ b/test/nova-test.js
@@ -513,22 +513,38 @@ exports.getServerLog = {
 
 
 exports.createServerImage = {
-  confirmResponseOnSuccess: function(test)
+  confirmResponseOnSuccessOldNova: function(test)
   {
     var mock_request = {
       post: function(options_array, callback){
-        callback(null, {statusCode: 200, headers: {location: '/images/image_id'}}, {output: {result: 'result'}});
+        callback(null, {statusCode: 200, headers: {location: '/images/mock_id'}}, {output: {result: 'result'}});
       }
     };
     nova.setRequest(mock_request);
 
     nova.createServerImage('mock_id', {meh: 'meh'}, function(error, result){
       test.ifError(error, 'There should be no error');
-      test.deepEqual({result: 'result', ImageId: 'image_id'}, result, 'value should be {result: "result", ImageId: "image_id"}');
+      test.deepEqual({image_id: 'mock_id'}, result, 'value should be {image_id: "mock_id"}');
       test.done();
     });
   },
 
+  confirmResponseOnSuccessNewNova: function(test)
+  {
+    var mock_request = {
+      post: function(options_array, callback){
+        callback(null, {statusCode: 200}, {image_id: 'mock_id'});
+      }
+    };
+    nova.setRequest(mock_request);
+
+    nova.createServerImage('mock_id', {meh: 'meh'}, function(error, result){
+      test.ifError(error, 'There should be no error');
+      test.deepEqual({image_id: 'mock_id'}, result, 'value should be {image_id: "mock_id"}');
+      test.done();
+    });
+  },
+  
   confirmErrorOnError: function(test)
   {
     //stub out some junk with an error


### PR DESCRIPTION
 - Updated Nova.createServerImage so that it now supports newer nova output formats for this call
 - Updated tests to account for both old and new output formats (method supports both)
 - Incremented minor version to indicate a minor incompatibility
 - Updated readme to indicate incompatibility change